### PR TITLE
Fix healthcheck URL in docker-compose file

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,12 +323,6 @@ services:
     volumes:
       - paikka-data:/data
       - paikka-stats:/stats
-    healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/api/v1/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 40s
 
 volumes:
   paikka-data:

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ services:
       - paikka-data:/data
       - paikka-stats:/stats
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/api/v1/health"]
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/api/v1/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - paikka-data:/data
       - paikka-stats:/stats
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/api/v1/health"]
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/api/v1/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,12 +12,6 @@ services:
     volumes:
       - paikka-data:/data
       - paikka-stats:/stats
-    healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/api/v1/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 40s
 
 volumes:
   paikka-data:


### PR DESCRIPTION
The docker image doesn't contain `curl` so the health check would always fail. Using `wget` fixes this :)